### PR TITLE
docs: bootstrap repo-aware documentation layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- Documentation scaffold in `docs/`.
+- Contributing guidelines and style guide.
+
+### Existing
+- Basic `main.py` entry point.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code owners for this repository
+* @rollmops94

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+## Development Workflow
+1. Create a feature branch from `main`.
+2. Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+3. Ensure Python 3.11 or later is installed.
+4. Run `pytest` and lint checks before submitting a pull request.
+
+## Pull Requests
+- Keep changes focused.
+- Update documentation and tests.
+
+## Code Style
+- See [docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md).

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,25 @@
+# API Reference
+
+## `main.main`
+
+```python
+def main() -> None
+```
+
+Run the main function.
+
+**Parameters**
+- None
+
+**Returns**
+- `None`
+
+**Raises**
+- None
+
+**Example**
+```python
+from main import main
+
+main()
+```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Architecture
+
+This project is a minimal Python application. It currently consists of a single module, `main.py`, which provides a `main()` entry point.
+
+## Layers
+- **CLI Layer**: `main.py` provides a command-line entry point that prints a message.
+
+## High-level Data Flow
+1. User runs `python main.py`.
+2. The `main()` function executes and prints a confirmation message to standard output.
+
+## Extension Points
+- Add new modules under `src/` or additional functions in `main.py`.
+- Future CLI commands can be registered in `main.py` within the `main()` function.
+
+## Internal Dependencies
+- None beyond the standard library.
+
+## External Dependencies
+- Python 3.11 or later.
+
+## Related ADRs
+- [Initial Architecture](DESIGN_DECISIONS/ADR-20250826-initial-architecture.md)

--- a/docs/DESIGN_DECISIONS/ADR-20250826-initial-architecture.md
+++ b/docs/DESIGN_DECISIONS/ADR-20250826-initial-architecture.md
@@ -1,0 +1,14 @@
+# ADR 20250826: initial-architecture
+
+## Status
+Accepted
+
+## Context
+The project starts as a simple Python script with a single entry point.
+
+## Decision
+Use a minimal structure with `main.py` as the executable module. Future modules can be added under a `src/` directory when needed.
+
+## Consequences
+- Simple to run and maintain.
+- Lacks modular structure until expanded.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,7 @@
+# Glossary
+
+| Term | Definition |
+|------|------------|
+| ADR | Architecture Decision Record documenting a design choice. |
+| CLI | Command-line interface. |
+| Runbook | Step-by-step operational guide for a routine task. |

--- a/docs/HOWTOS/adding_a_feature.md
+++ b/docs/HOWTOS/adding_a_feature.md
@@ -1,0 +1,7 @@
+# Adding a Feature
+
+1. Create a new function in `main.py` or a module under `src/`.
+2. Add docstrings and type hints.
+3. Update [`docs/MODULE_INDEX.md`](../MODULE_INDEX.md) and [`docs/API_REFERENCE.md`](../API_REFERENCE.md).
+4. Add tests under `tests/`.
+5. Run `pytest` before submitting a pull request.

--- a/docs/HOWTOS/running_the_program.md
+++ b/docs/HOWTOS/running_the_program.md
@@ -1,0 +1,8 @@
+# Running the Program
+
+1. Ensure Python 3.11 or later is installed.
+2. Execute the script:
+   ```bash
+   python main.py
+   ```
+3. The program prints a confirmation message.

--- a/docs/MODULE_INDEX.md
+++ b/docs/MODULE_INDEX.md
@@ -1,0 +1,8 @@
+# Module Index
+
+| Module | Symbol | Description | Path | Stability |
+|--------|--------|-------------|------|-----------|
+| `main` | `main()` | Run the main function. | `main.py` | Public |
+
+### TODOs
+- None

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -1,0 +1,16 @@
+# Prompts
+
+## Add new function
+- **Role**: Contributor
+- **Context**: `main.py`, `docs/STYLE_GUIDE.md`
+- **Output**: Patch adding function with tests and updated docs.
+
+## Regenerate API reference
+- **Role**: Documentation bot
+- **Context**: `docs/MODULE_INDEX.md`, `src/**/*.py` or `main.py`
+- **Output**: Updated `docs/API_REFERENCE.md`.
+
+## Refactor with ADR
+- **Role**: Maintainer
+- **Context**: Relevant source files, `docs/DESIGN_DECISIONS/`
+- **Output**: Code changes and new ADR documenting rationale.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Project Documentation
+
+Welcome to the documentation for this repository. The documents below provide an overview of the codebase, design decisions, and practical guides for contributors.
+
+## Table of Contents
+- [Architecture](ARCHITECTURE.md)
+- [System Context](SYSTEM_CONTEXT.md)
+- [Module Index](MODULE_INDEX.md)
+- [API Reference](API_REFERENCE.md)
+- [Design Decisions](DESIGN_DECISIONS/ADR-20250826-initial-architecture.md)
+- [How-Tos](HOWTOS/)
+- [Runbooks](RUNBOOKS/)
+- [Glossary](GLOSSARY.md)
+- [Style Guide](STYLE_GUIDE.md)
+- [Test Strategy](TEST_STRATEGY.md)
+- [Roadmap](ROADMAP.md)
+- [Task Registry](TASK_REGISTRY.md)
+- [Prompts](PROMPTS.md)
+- [Documentation Manifest](docs.manifest.yaml)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,6 @@
+# Roadmap
+
+## Short-term
+- Introduce `src/` package structure (see [ADR 20250826](DESIGN_DECISIONS/ADR-20250826-initial-architecture.md)).
+- Add unit tests for `main.py`.
+- Configure formatting tools (`black`, `isort`).

--- a/docs/RUNBOOKS/release_cut.md
+++ b/docs/RUNBOOKS/release_cut.md
@@ -1,0 +1,10 @@
+# Release Cut
+
+1. Update `CHANGELOG.md` with release notes.
+2. Commit changes with `chore: prepare release`.
+3. Tag the commit:
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+4. Create a GitHub release if applicable.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,14 @@
+# Style Guide
+
+## Python Formatting
+- **Black** with default line length (88) // NOTE: tool not yet configured.
+- **isort** for import sorting // NOTE: tool not yet configured.
+
+## Type Hints
+- Use Python type hints for all functions.
+
+## Logging
+- Use `print` for simple scripts. Introduce `logging` module when complexity grows.
+
+## Error Handling
+- Raise specific exceptions and document them in docstrings.

--- a/docs/SYSTEM_CONTEXT.md
+++ b/docs/SYSTEM_CONTEXT.md
@@ -1,0 +1,18 @@
+# System Context
+
+The application is a standalone Python script with minimal external interaction.
+
+## Inputs
+- No external inputs are consumed.
+
+## Outputs
+- Prints a message to standard output: `"This main file was created by ChatGPT."`
+
+## External Services
+- None.
+
+## Environment Requirements
+- Python 3.11 or later
+
+## File Formats
+- Not applicable.

--- a/docs/TASK_REGISTRY.md
+++ b/docs/TASK_REGISTRY.md
@@ -1,0 +1,9 @@
+# Task Registry
+
+| ID | Path | Acceptance Criteria | Status |
+|----|------|---------------------|--------|
+| TST-001 | `tests/test_main.py` | Test asserts `main()` prints message. | open |
+| DOC-002 | `README.md` | Expand project description. | open |
+| CFG-003 | `pyproject.toml` | Configure Black and isort. | open |
+| PKG-004 | `src/` | Introduce package structure with modules. | open |
+| CI-005 | `.github/workflows/ci.yml` | Setup CI pipeline running tests. | open |

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -1,0 +1,12 @@
+# Test Strategy
+
+Currently, no automated tests are implemented.
+
+## Planned Test Types
+- **Unit tests** using `pytest`.
+
+## Coverage Goals
+- Aim for 80% line coverage once tests exist.
+
+## Module to Test Mapping
+- `main.py` → *no tests yet* // TODO: add `tests/test_main.py`.

--- a/docs/docs.manifest.yaml
+++ b/docs/docs.manifest.yaml
@@ -1,0 +1,73 @@
+docs:
+  - file: docs/README.md
+    purpose: Entry point to project documentation
+    owner: rollmops94
+    generated_from: [main.py, docs/**/*]
+  - file: docs/ARCHITECTURE.md
+    purpose: Describe project structure and data flow
+    owner: rollmops94
+    generated_from: [main.py]
+  - file: docs/SYSTEM_CONTEXT.md
+    purpose: Outline external inputs and environment
+    owner: rollmops94
+    generated_from: [main.py]
+  - file: docs/MODULE_INDEX.md
+    purpose: Map modules to public APIs
+    owner: rollmops94
+    generated_from: [main.py]
+  - file: docs/API_REFERENCE.md
+    purpose: Detail API signatures
+    owner: rollmops94
+    generated_from: [main.py]
+  - file: docs/DESIGN_DECISIONS/ADR-20250826-initial-architecture.md
+    purpose: Record initial architectural choices
+    owner: rollmops94
+    generated_from: [git:commits]
+  - file: docs/HOWTOS/adding_a_feature.md
+    purpose: Guide for adding new features
+    owner: rollmops94
+    generated_from: [docs/STYLE_GUIDE.md, main.py]
+  - file: docs/HOWTOS/running_the_program.md
+    purpose: Instructions for running the script
+    owner: rollmops94
+    generated_from: [main.py]
+  - file: docs/RUNBOOKS/release_cut.md
+    purpose: Steps to cut a release
+    owner: rollmops94
+    generated_from: [CHANGELOG.md, git:tags]
+  - file: docs/GLOSSARY.md
+    purpose: Define project terms
+    owner: rollmops94
+    generated_from: [docs/**/*]
+  - file: docs/STYLE_GUIDE.md
+    purpose: Coding style conventions
+    owner: rollmops94
+    generated_from: [None]
+  - file: docs/TEST_STRATEGY.md
+    purpose: Testing approach
+    owner: rollmops94
+    generated_from: [tests/**/*]
+  - file: docs/ROADMAP.md
+    purpose: Planned future work
+    owner: rollmops94
+    generated_from: [docs/DESIGN_DECISIONS/*]
+  - file: docs/TASK_REGISTRY.md
+    purpose: List of small tasks
+    owner: rollmops94
+    generated_from: [docs/**/*]
+  - file: docs/PROMPTS.md
+    purpose: Reusable prompts for contributors
+    owner: rollmops94
+    generated_from: [docs/**/*]
+  - file: CONTRIBUTING.md
+    purpose: Contribution guidelines
+    owner: rollmops94
+    generated_from: [docs/STYLE_GUIDE.md]
+  - file: CHANGELOG.md
+    purpose: Track project changes
+    owner: rollmops94
+    generated_from: [git:commits]
+  - file: CODEOWNERS
+    purpose: Define code owners
+    owner: rollmops94
+    generated_from: [git:blame]


### PR DESCRIPTION
## Summary
- add repository-wide documentation scaffold and manifest
- document architecture, style, testing gaps, and roadmap
- establish task registry and contribution guidelines

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad67b7ea4083229051867370108a3b